### PR TITLE
fix link to uncertainty-toolbox logo

### DIFF
--- a/_projects/project_uncertainty_toolbox.md
+++ b/_projects/project_uncertainty_toolbox.md
@@ -2,7 +2,7 @@
 layout: page
 title: Uncertainty Toolbox
 description: A python toolbox for predictive uncertainty quantification, calibration, metrics, and visualization.
-img: https://github.com/uncertainty-toolbox/uncertainty-toolbox/raw/master/docs/images/logo.svg
+img: https://raw.githubusercontent.com/uncertainty-toolbox/uncertainty-toolbox/master/docs/images/logo.svg
 importance: 9
 category: project
 redirect: https://github.com/uncertainty-toolbox/uncertainty-toolbox


### PR DESCRIPTION
update the link to the svg logo in the uncertainty-toolbox project page so that it renders correctly